### PR TITLE
EBT V1

### DIFF
--- a/.github/workflows/prepare.yml
+++ b/.github/workflows/prepare.yml
@@ -14,7 +14,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [18.x, 20.x]
+        node-version: [20.x]
         # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
 
     steps:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@elastic/ebt",
-  "version": "0.0.3",
+  "version": "1.0.0",
   "description": "Event-based telemetry for Elastic products",
   "repository": "git@github.com:elastic/ebt.git",
   "license": "SSPL-1.0 OR Elastic License 2.0",

--- a/src/client/README.md
+++ b/src/client/README.md
@@ -13,8 +13,6 @@ const analytics = createAnalytics({
   // Set to `true` when running in developer mode.
   // It enables development helpers like schema validation and extra debugging features.
   isDev: false,
-  // Set to `staging` if you don't want your events to be sent to the production cluster. Useful for CI & QA environments.
-  sendTo: 'production',
   // The application's instrumented logger 
   logger,
 });

--- a/src/client/src/analytics_client/analytics_client.test.ts
+++ b/src/client/src/analytics_client/analytics_client.test.ts
@@ -24,7 +24,6 @@ describe('AnalyticsClient', () => {
     analyticsClient = new AnalyticsClient({
       logger,
       isDev: true,
-      sendTo: 'staging',
     });
   });
 

--- a/src/client/src/analytics_client/types.ts
+++ b/src/client/src/analytics_client/types.ts
@@ -25,10 +25,6 @@ export interface AnalyticsClientInitContext {
    */
   isDev: boolean;
   /**
-   * Specify if the shippers should send their data to the production or staging environments.
-   */
-  sendTo: 'production' | 'staging';
-  /**
    * Application-provided logger.
    */
   logger: Logger;

--- a/src/shippers/elastic_v3/browser/src/browser_shipper.test.ts
+++ b/src/shippers/elastic_v3/browser/src/browser_shipper.test.ts
@@ -23,7 +23,6 @@ describe('ElasticV3BrowserShipper', () => {
   ];
 
   const initContext: AnalyticsClientInitContext = {
-    sendTo: 'staging',
     isDev: true,
     logger: loggerMock.create(),
   };
@@ -55,16 +54,6 @@ describe('ElasticV3BrowserShipper', () => {
   afterEach(() => {
     shipper.shutdown();
     jest.useRealTimers();
-  });
-
-  test("custom sendTo overrides Analytics client's", () => {
-    const prodShipper = new ElasticV3BrowserShipper(
-      { version: '1.2.3', channelName: 'test-channel', debug: true, sendTo: 'production', buildShipperHeaders, buildShipperUrl },
-      initContext
-    );
-
-    // eslint-disable-next-line dot-notation
-    expect(prodShipper['url']).not.toEqual(shipper['url']);
   });
 
   test('set optIn should update the isOptedIn$ observable', () => {

--- a/src/shippers/elastic_v3/browser/src/browser_shipper.ts
+++ b/src/shippers/elastic_v3/browser/src/browser_shipper.ts
@@ -70,7 +70,6 @@ export class ElasticV3BrowserShipper implements IShipper {
     }
     this.buildHeaders = options.buildShipperHeaders;
     this.url = options.buildShipperUrl({
-      sendTo: options.sendTo ?? initContext.sendTo,
       channelName: options.channelName,
     });
   }

--- a/src/shippers/elastic_v3/common/src/__mocks__/build_url.ts
+++ b/src/shippers/elastic_v3/common/src/__mocks__/build_url.ts
@@ -1,11 +1,8 @@
 import { BuildShipperHeaders, BuildShipperUrl, BuildShipperUrlOptions } from "../types";
 
 export const buildShipperUrl: BuildShipperUrl = (urlOptions: BuildShipperUrlOptions): string => {
-  const { sendTo, channelName } = urlOptions;
-  const baseUrl =
-    sendTo === 'production'
-      ? 'https://telemetry.elastic.co'
-      : 'https://telemetry-staging.elastic.co';
+  const { channelName } = urlOptions;
+  const baseUrl = 'https://telemetry-staging.elastic.co';
   return `${baseUrl}/v3/send/${channelName}`;
 }
 

--- a/src/shippers/elastic_v3/common/src/types.ts
+++ b/src/shippers/elastic_v3/common/src/types.ts
@@ -19,10 +19,6 @@ export interface ElasticV3ShipperOptions {
    */
   version: string;
   /**
-   * Provide it to override the Analytics client's default configuration.
-   */
-  sendTo?: 'staging' | 'production';
-  /**
    * Should show debug information about the requests it makes to the V3 API.
    */
   debug?: boolean;
@@ -41,8 +37,6 @@ export type BuildShipperHeaders = (clusterUuid: string, version: string, license
 
 /** The options to build the URL of the V3 API. */
 export interface BuildShipperUrlOptions {
-  /** Whether to send it to production or staging. */
-  sendTo: 'production' | 'staging';
   /** The name of the channel to send the data to. */
   channelName: string;
 }

--- a/src/shippers/elastic_v3/server/src/server_shipper.test.ts
+++ b/src/shippers/elastic_v3/server/src/server_shipper.test.ts
@@ -27,7 +27,6 @@ describe('ElasticV3ServerShipper', () => {
   ];
 
   const initContext: AnalyticsClientInitContext = {
-    sendTo: 'staging',
     isDev: true,
     logger: loggerMock.create(),
   };

--- a/src/shippers/elastic_v3/server/src/server_shipper.ts
+++ b/src/shippers/elastic_v3/server/src/server_shipper.ts
@@ -102,7 +102,6 @@ export class ElasticV3ServerShipper implements IShipper {
     }
     this.buildHeaders = options.buildShipperHeaders;
     this.url = options.buildShipperUrl({
-      sendTo: options.sendTo ?? initContext.sendTo,
       channelName: options.channelName,
     });
     this.setInternalSubscriber();

--- a/src/shippers/fullstory/src/fullstory_shipper.test.ts
+++ b/src/shippers/fullstory/src/fullstory_shipper.test.ts
@@ -22,7 +22,6 @@ describe('FullStoryShipper', () => {
       },
       {
         logger: loggerMock.create(),
-        sendTo: 'staging',
         isDev: true,
       }
     );
@@ -190,7 +189,6 @@ describe('FullStoryShipper', () => {
         },
         {
           logger: loggerMock.create(),
-          sendTo: 'staging',
           isDev: true,
         }
       );


### PR DESCRIPTION
Moved code from Kibana to this repo.
Significant changes:
1. Removed `lodash.set` because it is unsafe to use for us. Replaced it by manually setting the page vars and page labels into the object reduce.
2. Created a trimmed `Logger` interface since we dont have the kbn/logger package published on npm. We expect the logger interface to have a specific signature so the types uses the minimum requirements only.
3. Version `1.0.0` will be the first used version in Kibana. currently the package is published under `0.0.x~beta` for testing the integration with kibana and the CI.
4. The telemetry endpoint `build_url` and `build_headers` are now expected as config parameters instead of having them hardcoded in the codebase. This way users of the package can change the headers or endpoint with flexiblity.
5. The build process builds the `client` and `shippers` to the root of the repo this way users of the package can import sub packages as needed. This is used in favor of a monorepo managed by turbo or such for simplicity, this should be enough to meet our needs.