### PR TITLE
chore(npmignore): ignore additional files

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -3,6 +3,8 @@ coverage
 yarn-error.log
 .github
 .prettierrc.js
+renovate.json
+jest.config.js
 tsconfig.base.json
 tsconfig.jest.json
 tsconfig.json


### PR DESCRIPTION
Looking at the [code published with the library](https://www.npmjs.com/package/@elastic/ebt?activeTab=code), adding some files that we don't need to ship in the npm package.