### PR TITLE
Remove `https://` prefix from raw snippet

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,8 +22,7 @@
     "lodash.has": "^4.5.2",
     "moment": "^2.30.1",
     "node-fetch": "^2.6.7",
-    "rxjs": "^7.8.1",
-    "typescript": "^5.5.4"
+    "rxjs": "^7.8.1"
   },
   "devDependencies": {
     "@fullstory/snippet": "^2.0.4",
@@ -35,6 +34,7 @@
     "jest-environment-jsdom": "^29.7.0",
     "prettier": "^3.3.3",
     "rimraf": "^6.0.1",
-    "ts-jest": "^29.2.4"
+    "ts-jest": "^29.2.4",
+    "typescript": "^5.5.4"
   }
 }

--- a/src/shippers/fullstory/src/raw_snippet.ts
+++ b/src/shippers/fullstory/src/raw_snippet.ts
@@ -12,7 +12,7 @@ then:function(b,h){return p((function(r,i){d.push([b,h,r,i]),j()}))}}}a&&(g=m[e]
 h(b,d,j,i,c,r)}r=r||2;var c,u=/Async$/;return u.test(b)?(b=b.replace(u,""),"function"==typeof Promise?new Promise(i):p(i)):h(b,d,j,c,c,r)}
 ;function h(h,d,j,r,i,c){return b._api?b._api(h,d,j,r,i,c):(b.q&&b.q.push([h,d,j,r,i,c]),null)}return b.q=[],b}(),y=function(b){function h(h){
 "function"==typeof h[4]&&h[4](new Error(b))}var d=g.q;if(d){for(var j=0;j<d.length;j++)h(d[j]);d.length=0,d.push=h}},function(){
-(o=n.createElement(t)).async=!0,o.crossOrigin="anonymous",o.src="https://"+l,o.onerror=function(){y("Error loading "+l)}
+(o=n.createElement(t)).async=!0,o.crossOrigin="anonymous",o.src=l,o.onerror=function(){y("Error loading "+l)}
 ;var b=n.getElementsByTagName(t)[0];b&&b.parentNode?b.parentNode.insertBefore(o,b):n.head.appendChild(o)}(),function(){function b(){}
 function h(b,h,d){g(b,h,d,1)}function d(b,d,j){h("setProperties",{type:b,properties:d},j)}function j(b,h){d("user",b,h)}function r(b,h,d){j({
 uid:b},d),h&&j(h,d)}g.identify=r,g.setUserVars=j,g.identifyAccount=b,g.clearUserCookie=b,g.setVars=d,g.event=function(b,d,j){h("trackEvent",{


### PR DESCRIPTION
Because Kibana provides a local path to load the "remote" script, the snippet cannot prepend `https://` or the URL is malformed, looking like `https:///internal/cloud/${buildNum}/fullstory.js`.

On top of that, moving `typescript` to a dev dependency (it's not needed for runtime)