### PR TITLE
Add getTraceContext function to the AnalyticsClient

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@
 index.js
 index.d.ts
 yarn-error.log
+.idea

--- a/src/client/src/analytics_client/analytics_client.test.ts
+++ b/src/client/src/analytics_client/analytics_client.test.ts
@@ -11,19 +11,29 @@ import { Subject, lastValueFrom, take, toArray } from 'rxjs';
 import { loggerMock, type MockedLogger } from './__mocks__/logger';
 import { AnalyticsClient } from './analytics_client';
 import { shippersMock } from '../shippers/mocks';
-import type { TelemetryCounter } from '../events';
+import type { TelemetryCounter, TraceContext } from '../events';
 import { ContextService } from './context_service';
 
 describe('AnalyticsClient', () => {
   let analyticsClient: AnalyticsClient;
   let logger: MockedLogger;
+  const traceContext: TraceContext = {
+    id: 'mocked-trace-id'
+  }
 
   beforeEach(() => {
     jest.useFakeTimers();
     logger = loggerMock.create();
+    let counter = 1;
     analyticsClient = new AnalyticsClient({
       logger,
       isDev: true,
+      getTraceContext: () => {
+        return {
+          ...traceContext,
+          id: `${traceContext.id ?? ''}-${counter++}`
+        }
+      },
     });
   });
 
@@ -165,18 +175,30 @@ describe('AnalyticsClient', () => {
           event_type: 'testEvent',
           properties: { a_field: 'a' },
           timestamp: expect.any(String),
+          trace: {
+            ...traceContext,
+            id: traceContext.id + '-1'
+          },
         },
         {
           context: {},
           event_type: 'testEvent',
           properties: { a_field: 'b' },
           timestamp: expect.any(String),
+          trace: {
+            ...traceContext,
+            id: traceContext.id + '-2'
+          },
         },
         {
           context: {},
           event_type: 'testEvent',
           properties: { a_field: 'c' },
           timestamp: expect.any(String),
+          trace: {
+            ...traceContext,
+            id: traceContext.id + '-3'
+          },
         },
       ]);
     });
@@ -215,6 +237,10 @@ describe('AnalyticsClient', () => {
           event_type: 'testEvent',
           properties: {},
           context: {},
+          trace: {
+            ...traceContext,
+            id: traceContext.id + '-1'
+          },
         },
       ]);
       expect(logger.warn).toHaveBeenCalledWith(
@@ -601,12 +627,20 @@ describe('AnalyticsClient', () => {
           event_type: 'event-type-a',
           properties: { a_field: 'a' },
           timestamp: expect.any(String),
+          trace: {
+            ...traceContext,
+            id: traceContext.id + '-1'
+          },
         },
         {
           context: {},
           event_type: 'event-type-b',
           properties: { b_field: 100 },
           timestamp: expect.any(String),
+          trace: {
+            ...traceContext,
+            id: traceContext.id + '-2'
+          },
         },
       ]);
     });
@@ -635,12 +669,20 @@ describe('AnalyticsClient', () => {
           event_type: 'event-type-a',
           properties: { a_field: 'a' },
           timestamp: expect.any(String),
+          trace: {
+            ...traceContext,
+            id: traceContext.id + '-1'
+          },
         },
         {
           context: {},
           event_type: 'event-type-a',
           properties: { a_field: 'b' },
           timestamp: expect.any(String),
+          trace: {
+            ...traceContext,
+            id: traceContext.id + '-3'
+          },
         },
       ]);
       expect(reportEventsMock).toHaveBeenNthCalledWith(2, [
@@ -649,6 +691,10 @@ describe('AnalyticsClient', () => {
           event_type: 'event-type-b',
           properties: { b_field: 100 },
           timestamp: expect.any(String),
+          trace: {
+            ...traceContext,
+            id: traceContext.id + '-2'
+          },
         },
       ]);
 
@@ -823,6 +869,10 @@ describe('AnalyticsClient', () => {
           event_type: 'event-type-b',
           properties: { b_field: 100 },
           timestamp: expect.any(String),
+          trace: {
+            ...traceContext,
+            id: traceContext.id + '-2'
+          },
         },
       ]);
 
@@ -889,12 +939,20 @@ describe('AnalyticsClient', () => {
           event_type: 'event-type-a',
           properties: { a_field: 'a' },
           timestamp: expect.any(String),
+          trace: {
+            ...traceContext,
+            id: traceContext.id + '-1'
+          },
         },
         {
           context: {},
           event_type: 'event-type-a',
           properties: { a_field: 'b' },
           timestamp: expect.any(String),
+          trace: {
+            ...traceContext,
+            id: traceContext.id + '-3'
+          },
         },
       ]);
       expect(reportEventsMock1).toHaveBeenNthCalledWith(2, [
@@ -903,6 +961,10 @@ describe('AnalyticsClient', () => {
           event_type: 'event-type-b',
           properties: { b_field: 100 },
           timestamp: expect.any(String),
+          trace: {
+            ...traceContext,
+            id: traceContext.id + '-2'
+          },
         },
       ]);
       expect(reportEventsMock2).toHaveBeenCalledTimes(1);
@@ -912,6 +974,10 @@ describe('AnalyticsClient', () => {
           event_type: 'event-type-b',
           properties: { b_field: 100 },
           timestamp: expect.any(String),
+          trace: {
+            ...traceContext,
+            id: traceContext.id + '-2'
+          },
         },
       ]);
 
@@ -985,12 +1051,20 @@ describe('AnalyticsClient', () => {
           event_type: 'event-type-a',
           properties: { a_field: 'a' },
           timestamp: expect.any(String),
+          trace: {
+            ...traceContext,
+            id: traceContext.id + '-1'
+          },
         },
         {
           context: {},
           event_type: 'event-type-a',
           properties: { a_field: 'b' },
           timestamp: expect.any(String),
+          trace: {
+            ...traceContext,
+            id: traceContext.id + '-3'
+          },
         },
       ]);
       expect(reportEventsMock1).toHaveBeenNthCalledWith(2, [
@@ -999,6 +1073,10 @@ describe('AnalyticsClient', () => {
           event_type: 'event-type-b',
           properties: { b_field: 100 },
           timestamp: expect.any(String),
+          trace: {
+            ...traceContext,
+            id: traceContext.id + '-2'
+          },
         },
       ]);
       expect(reportEventsMock2).toHaveBeenCalledTimes(0);
@@ -1109,6 +1187,10 @@ describe('AnalyticsClient', () => {
           event_type: 'event-type-a',
           properties: { a_field: 'a' },
           timestamp: expect.any(String),
+          trace: {
+            ...traceContext,
+            id: traceContext.id + '-1'
+          },
         },
       ]);
       expect(reportEventsMock).toHaveBeenNthCalledWith(2, [
@@ -1117,6 +1199,10 @@ describe('AnalyticsClient', () => {
           event_type: 'event-type-b',
           properties: { b_field: 100 },
           timestamp: expect.any(String),
+          trace: {
+            ...traceContext,
+            id: traceContext.id + '-2'
+          },
         },
       ]);
       expect(reportEventsMock).toHaveBeenNthCalledWith(3, [
@@ -1125,6 +1211,10 @@ describe('AnalyticsClient', () => {
           event_type: 'event-type-a',
           properties: { a_field: 'b' },
           timestamp: expect.any(String),
+          trace: {
+            ...traceContext,
+            id: traceContext.id + '-3'
+          },
         },
       ]);
 

--- a/src/client/src/analytics_client/analytics_client.ts
+++ b/src/client/src/analytics_client/analytics_client.ts
@@ -115,6 +115,7 @@ export class AnalyticsClient implements IAnalyticsClient {
       event_type: eventType,
       context: this.context$.value,
       properties: eventData as unknown as Record<string, unknown>,
+      trace: this.initContext?.getTraceContext?.(),
     };
 
     this.initContext.logger.debug(`Report event "${eventType}"`, {

--- a/src/client/src/analytics_client/types.ts
+++ b/src/client/src/analytics_client/types.ts
@@ -13,7 +13,7 @@ import type { Observable } from 'rxjs';
 import type { Logger } from './logger_types';
 
 import type { IShipper } from '../shippers';
-import type { EventType, TelemetryCounter } from '../events';
+import type { EventType, TelemetryCounter, TraceContext } from '../events';
 import type { RootSchema } from '../schema';
 
 /**
@@ -28,6 +28,10 @@ export interface AnalyticsClientInitContext {
    * Application-provided logger.
    */
   logger: Logger;
+  /**
+   * A function to get trace.id
+   */
+  getTraceContext?: () => TraceContext | undefined;
 }
 
 /**

--- a/src/client/src/events/index.ts
+++ b/src/client/src/events/index.ts
@@ -6,4 +6,4 @@
  * Side Public License, v 1.
  */
 
-export type { Event, EventType, EventContext, TelemetryCounter, TelemetryCounterType } from './types';
+export type { Event, EventType, EventContext, TelemetryCounter, TelemetryCounterType, TraceContext } from './types';

--- a/src/client/src/events/types.ts
+++ b/src/client/src/events/types.ts
@@ -120,4 +120,15 @@ export interface Event<Properties = Record<string, unknown>> {
    * The {@link EventContext} enriched during the processing pipeline.
    */
   context: EventContext;
+  /**
+   * The trace context.
+   */
+  trace?: TraceContext;
+}
+
+export type TraceContext = {
+    /**
+     * The trace ID.
+     */
+    id: string | undefined;
 }


### PR DESCRIPTION
Related to https://github.com/elastic/observability-dev/issues/4445

### Summary

This PR adds a getTraceContext function to the AnalyticsClient in order to set the trace.id from kibana.