### PR TITLE
Push tags to upstream repo

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "prepare": "yarn clean && yarn lint -c && yarn test:unit && yarn build",
     "preversion": "yarn",
     "version": "git checkout -b $(node scripts/get_package_version) && git add .",
-    "postversion": "git push --set-upstream origin $(node scripts/get_package_version) && git push --tags",
+    "postversion": "git push --set-upstream origin $(node scripts/get_package_version) && git push upstream --tags",
     "test:coverage": "jest --coverage"
   },
   "dependencies": {


### PR DESCRIPTION
I noticed that the current tags were pushed to the `origin` remote, so it didn't show in this repo.