### PR TITLE
use trusted-publishers

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -2,6 +2,11 @@ name: Publish Package to npmjs
 on:
   release:
     types: [published]
+
+permissions:
+  id-token: write
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -11,9 +16,8 @@ jobs:
         with:
           node-version: '20.x'
           registry-url: 'https://registry.npmjs.org'
-          # Defaults to the user or organization that owns the workflow file
           scope: '@elastic'
       - run: yarn
       - run: yarn publish
         env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NPM_CONFIG_PROVENANCE: true

--- a/package.json
+++ b/package.json
@@ -6,6 +6,9 @@
   "license": "SSPL-1.0 OR Elastic License 2.0",
   "main": "index.js",
   "packageManager": "yarn@1.22.22",
+  "publishConfig": {
+    "provenance": true
+  },
   "scripts": {
     "build": "tsc --build",
     "clean": "tsc --build --clean && rimraf client shippers",


### PR DESCRIPTION
Publish with https://docs.npmjs.com/trusted-publishers instead of npm tokens