### PR TITLE
[ElasticV3ServerShipper] Expose leaky bucket options

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -54,5 +54,5 @@ export type { GlobalSessionContextProviderOpts } from './helpers/global_session'
 // Shippers
 export type { ElasticV3ShipperOptions } from './shippers/elastic_v3/common';
 export type { ElasticV3BrowserShipper } from './shippers/elastic_v3/browser';
-export type { ElasticV3ServerShipper } from './shippers/elastic_v3/server';
+export type { ElasticV3ServerShipper, ElasticV3ServerShipperOptions } from './shippers/elastic_v3/server';
 export type { FullStoryShipperConfig, FullStoryShipper, FullStorySnippetConfig } from './shippers/fullstory';

--- a/src/shippers/elastic_v3/server/index.ts
+++ b/src/shippers/elastic_v3/server/index.ts
@@ -7,4 +7,4 @@
  */
 
 export type { ElasticV3ShipperOptions, BuildShipperHeaders, BuildShipperUrl, BuildShipperUrlOptions } from '../common';
-export { ElasticV3ServerShipper } from './src/server_shipper';
+export { ElasticV3ServerShipper, type ElasticV3ServerShipperOptions } from './src/server_shipper';


### PR DESCRIPTION
As the usage of EBT is growing on the server side, and we're learning more about it, we can confidently tweak these parameters. To avoid having to publish a new client whenever we update the constants. Let's make them configurable.