### PR TITLE
Workaound yarn publish OIDC incompatibility.

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -17,6 +17,5 @@ jobs:
           node-version: '24.x'
           registry-url: 'https://registry.npmjs.org'
       - run: yarn
-      - run: yarn publish
-        env:
-          NPM_CONFIG_PROVENANCE: true
+      # yarn publish does not work with OIDC publishing. This command is the workaround
+      - run: npm publish --provenance --access public


### PR DESCRIPTION
Replaced yarn publish with npm publish workaround for OIDC.

Reasoning: https://dev.to/devactivity/solving-the-not-found-error-seamless-oidc-publishing-to-npmjs-with-yarn-in-github-actions-161n